### PR TITLE
SVCPLAN-589: add vim-enhanced for all nodes

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -19,5 +19,6 @@ profile_additional_packages::pkg_list:
     "tcsh":
     "traceroute":
     "tree":
+    "vim-enhanced":
     "wget":
     "zsh":


### PR DESCRIPTION
Tested on control-test-*a nodes (and also hli-sched).